### PR TITLE
 [portsorch] Don't flap port when setting speed if port is down

### DIFF
--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -71,7 +71,8 @@ public:
     int                 m_index = 0;    // PHY_PORT: index
     uint32_t            m_mtu = DEFAULT_MTU;
     uint32_t            m_speed = 0;    // Mbps
-    bool                m_autoneg = 0;
+    bool                m_autoneg = false;
+    bool                m_admin_state = false;
     sai_object_id_t     m_port_id = 0;
     sai_port_fec_mode_t m_fec_mode = SAI_PORT_FEC_MODE_NONE;
     VlanInfo            m_vlan_info;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When port is already down during speed configuration don't put port down again.
Cache admin status in Port structure, do not set admin port status again if already set.

**Why I did it**
Avoid unnessesary SAI calls. It also had implications on Mellanox fastfast boot solution causing port flapping.

**How I verified it**
Verified it is passing all VS tests.
Mannual testing.

**Details if related**
