### PR TITLE
[ResponsePublisher] add pipeline support

### DIFF
--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -562,6 +562,11 @@ void Orch::dumpPendingTasks(vector<string> &ts)
     }
 }
 
+void Orch::flushResponses()
+{
+    m_publisher.flush();
+}
+
 void Orch::logfileReopen()
 {
     gRecordOfs.close();

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -223,6 +223,11 @@ public:
     static void recordTuple(Consumer &consumer, const swss::KeyOpFieldsValuesTuple &tuple);
 
     void dumpPendingTasks(std::vector<std::string> &ts);
+
+    /**
+     * @brief Flush pending responses
+     */
+    void flushResponses();
 protected:
     ConsumerMap m_consumerMap;
 

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -677,6 +677,11 @@ void OrchDaemon::flush()
         SWSS_LOG_ERROR("Failed to flush redis pipeline %d", status);
         abort();
     }
+
+    for (auto* orch: m_orchList)
+    {
+        orch->flushResponses();
+    }
 }
 
 /* Release the file handle so the log can be rotated */
@@ -689,11 +694,6 @@ void OrchDaemon::logRotate() {
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to release the file handle on sairedis log %d", status);
-    }
-
-    for (auto* orch: m_orchList)
-    {
-        orch->flushResponses();
     }
 }
 

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -690,6 +690,11 @@ void OrchDaemon::logRotate() {
     {
         SWSS_LOG_ERROR("Failed to release the file handle on sairedis log %d", status);
     }
+
+    for (auto* orch: m_orchList)
+    {
+        orch->flushResponses();
+    }
 }
 
 

--- a/orchagent/response_publisher.cpp
+++ b/orchagent/response_publisher.cpp
@@ -5,8 +5,6 @@
 #include <string>
 #include <vector>
 
-#include <swss/json.h>
-
 #include "timestamp.h"
 
 extern bool gResponsePublisherRecord;
@@ -114,14 +112,10 @@ void ResponsePublisher::publish(const std::string &table, const std::string &key
     std::string response_channel = "APPL_DB_" + table + "_RESPONSE_CHANNEL";
     swss::NotificationProducer notificationProducer{m_pipe.get(), response_channel, m_buffered};
 
-    auto intent_attrs_copy = state_attrs;
+    auto intent_attrs_copy = intent_attrs;
     // Add error message as the first field-value-pair.
     swss::FieldValueTuple err_str("err_str", PrependedComponent(status) + status.message());
     intent_attrs_copy.insert(intent_attrs_copy.begin(), err_str);
-    // Send state attrs
-    std::string state_attrs_serialized = swss::JSon::buildJson(state_attrs);
-    swss::FieldValueTuple state_attrs_fv("state_attrs", state_attrs_serialized);
-    intent_attrs_copy.insert(intent_attrs_copy.begin(), state_attrs_fv);
     // Sends the response to the notification channel.
     notificationProducer.send(status.codeStr(), key, intent_attrs_copy);
     RecordResponse(response_channel, key, intent_attrs_copy, status.codeStr());

--- a/orchagent/response_publisher.cpp
+++ b/orchagent/response_publisher.cpp
@@ -5,6 +5,8 @@
 #include <string>
 #include <vector>
 
+#include <swss/json.h>
+
 #include "timestamp.h"
 
 extern bool gResponsePublisherRecord;
@@ -90,7 +92,10 @@ void RecordResponse(const std::string &response_channel, const std::string &key,
 
 } // namespace
 
-ResponsePublisher::ResponsePublisher() : m_db("APPL_STATE_DB", 0)
+ResponsePublisher::ResponsePublisher(bool buffered) :
+    m_db(std::make_unique<swss::DBConnector>("APPL_STATE_DB", 0)),
+    m_pipe(std::make_unique<swss::RedisPipeline>(m_db.get())),
+    m_buffered(buffered)
 {
 }
 
@@ -107,17 +112,18 @@ void ResponsePublisher::publish(const std::string &table, const std::string &key
     }
 
     std::string response_channel = "APPL_DB_" + table + "_RESPONSE_CHANNEL";
-    if (m_notifiers.find(table) == m_notifiers.end())
-    {
-        m_notifiers[table] = std::make_unique<swss::NotificationProducer>(&m_db, response_channel);
-    }
+    swss::NotificationProducer notificationProducer{m_pipe.get(), response_channel, m_buffered};
 
-    auto intent_attrs_copy = intent_attrs;
+    auto intent_attrs_copy = state_attrs;
     // Add error message as the first field-value-pair.
     swss::FieldValueTuple err_str("err_str", PrependedComponent(status) + status.message());
     intent_attrs_copy.insert(intent_attrs_copy.begin(), err_str);
+    // Send state attrs
+    std::string state_attrs_serialized = swss::JSon::buildJson(state_attrs);
+    swss::FieldValueTuple state_attrs_fv("state_attrs", state_attrs_serialized);
+    intent_attrs_copy.insert(intent_attrs_copy.begin(), state_attrs_fv);
     // Sends the response to the notification channel.
-    m_notifiers[table]->send(status.codeStr(), key, intent_attrs_copy);
+    notificationProducer.send(status.codeStr(), key, intent_attrs_copy);
     RecordResponse(response_channel, key, intent_attrs_copy, status.codeStr());
 }
 
@@ -140,17 +146,14 @@ void ResponsePublisher::publish(const std::string &table, const std::string &key
 void ResponsePublisher::writeToDB(const std::string &table, const std::string &key,
                                   const std::vector<swss::FieldValueTuple> &values, const std::string &op, bool replace)
 {
-    if (m_tables.find(table) == m_tables.end())
-    {
-        m_tables[table] = std::make_unique<swss::Table>(&m_db, table);
-    }
+    swss::Table applStateTable{m_pipe.get(), table, m_buffered};
 
     auto attrs = values;
     if (op == SET_COMMAND)
     {
         if (replace)
         {
-            m_tables[table]->del(key);
+            applStateTable.del(key);
         }
         if (!values.size())
         {
@@ -160,9 +163,9 @@ void ResponsePublisher::writeToDB(const std::string &table, const std::string &k
         // Write to DB only if the key does not exist or non-NULL attributes are
         // being written to the entry.
         std::vector<swss::FieldValueTuple> fv;
-        if (!m_tables[table]->get(key, fv))
+        if (!applStateTable.get(key, fv))
         {
-            m_tables[table]->set(key, attrs);
+            applStateTable.set(key, attrs);
             RecordDBWrite(table, key, attrs, op);
             return;
         }
@@ -179,13 +182,23 @@ void ResponsePublisher::writeToDB(const std::string &table, const std::string &k
         }
         if (attrs.size())
         {
-            m_tables[table]->set(key, attrs);
+            applStateTable.set(key, attrs);
             RecordDBWrite(table, key, attrs, op);
         }
     }
     else if (op == DEL_COMMAND)
     {
-        m_tables[table]->del(key);
+        applStateTable.del(key);
         RecordDBWrite(table, key, {}, op);
     }
+}
+
+void ResponsePublisher::flush()
+{
+    m_pipe->flush();
+}
+
+void ResponsePublisher::setBuffered(bool buffered)
+{
+    m_buffered = buffered;
 }

--- a/orchagent/response_publisher.h
+++ b/orchagent/response_publisher.h
@@ -16,7 +16,8 @@
 class ResponsePublisher : public ResponsePublisherInterface
 {
   public:
-    explicit ResponsePublisher();
+    explicit ResponsePublisher(bool buffered = false);
+
     virtual ~ResponsePublisher() = default;
 
     // Intent attributes are the attributes sent in the notification into the
@@ -42,10 +43,21 @@ class ResponsePublisher : public ResponsePublisherInterface
     void writeToDB(const std::string &table, const std::string &key, const std::vector<swss::FieldValueTuple> &values,
                    const std::string &op, bool replace = false) override;
 
+    /**
+     * @brief Flush pending responses
+    */
+    void flush();
+
+    /**
+     * @brief Set buffering mode
+     *
+     * @param buffered Flag whether responses are buffered
+    */
+    void setBuffered(bool buffered);
+
   private:
-    swss::DBConnector m_db;
-    // Maps table names to tables.
-    std::unordered_map<std::string, std::unique_ptr<swss::Table>> m_tables;
-    // Maps table names to notifiers.
-    std::unordered_map<std::string, std::unique_ptr<swss::NotificationProducer>> m_notifiers;
+    std::unique_ptr<swss::DBConnector> m_db;
+    std::unique_ptr<swss::RedisPipeline> m_pipe;
+
+    bool m_buffered{false};
 };

--- a/tests/mock_tests/fake_response_publisher.cpp
+++ b/tests/mock_tests/fake_response_publisher.cpp
@@ -3,7 +3,7 @@
 
 #include "response_publisher.h"
 
-ResponsePublisher::ResponsePublisher() : m_db("APPL_STATE_DB", 0) {}
+ResponsePublisher::ResponsePublisher(bool buffered) : m_db(std::make_unique<swss::DBConnector>("APPL_STATE_DB", 0)), m_buffered(buffered) {}
 
 void ResponsePublisher::publish(
     const std::string& table, const std::string& key,
@@ -20,3 +20,7 @@ void ResponsePublisher::writeToDB(
     const std::string& table, const std::string& key,
     const std::vector<swss::FieldValueTuple>& values, const std::string& op,
     bool replace) {}
+
+void ResponsePublisher::flush() {}
+
+void ResponsePublisher::setBuffered(bool buffered) {}


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

I added ResponsePublisher support for redis pipeline

**Why I did it**

I did it to improve performance when sending many responses. Responses are buffered in redis client before beeing sent out to redis server, while orchagent has no more pending tasks to do, responses are flushed to redis.

**How I verified it**

I did manual tests and verified togather with bgp suppress feature.

**Details if related**
