### PR TITLE
[RouteOrch] Record ROUTE_TABLE entry programming status to APPL_STATE_DB

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -838,8 +838,9 @@ void RouteOrch::doTask(Consumer& consumer)
                     /* fullmask subnet route is same as ip2me route */
                     else if (ip_prefix.isFullMask() && m_intfsOrch->isPrefixSubnet(ip_prefix, alsv[0]))
                     {
-                        /* We're not programming any route in this case but we do have to publish response
-                         * for it because the route was already programmed by IntfOrch as part of interface configuration */
+                        /* The prefix is full mask (/32 or /128) and it is an interface subnet route, so IntfOrch has already
+                         * created an IP2ME route for it and we skip programming such route here as it already exists.
+                         * However, to keep APPL_DB and APPL_STATE_DB consistent we have to publish it. */
                         publishRouteState(ctx, ReturnCode(SAI_STATUS_SUCCESS));
                         it = consumer.m_toSync.erase(it);
                     }
@@ -2603,7 +2604,7 @@ void RouteOrch::publishRouteState(const RouteBulkContext& ctx, const ReturnCode&
     if (!ctx.protocol.empty())
     {
         fvs.emplace_back("protocol", ctx.protocol);
-    };
+    }
 
     const bool replace = true;
 

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -47,6 +47,8 @@ RouteOrch::RouteOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames,
 {
     SWSS_LOG_ENTER();
 
+    m_publisher.setBuffered(true);
+
     sai_attribute_t attr;
     attr.id = SAI_SWITCH_ATTR_NUMBER_OF_ECMP_GROUPS;
 
@@ -499,7 +501,7 @@ void RouteOrch::doTask(Consumer& consumer)
 
             auto rc = toBulk.emplace(std::piecewise_construct,
                     std::forward_as_tuple(key, op),
-                    std::forward_as_tuple());
+                    std::forward_as_tuple(key));
 
             bool inserted = rc.second;
             auto& ctx = rc.first->second;
@@ -630,6 +632,11 @@ void RouteOrch::doTask(Consumer& consumer)
 
                     if (fvField(i) == "seg_src")
                         srv6_source = fvValue(i);
+
+                    if (fvField(i) == "protocol")
+                    {
+                        ctx.protocol = fvValue(i);
+                    }
                 }
 
                 /*
@@ -831,6 +838,9 @@ void RouteOrch::doTask(Consumer& consumer)
                     /* fullmask subnet route is same as ip2me route */
                     else if (ip_prefix.isFullMask() && m_intfsOrch->isPrefixSubnet(ip_prefix, alsv[0]))
                     {
+                        /* We're not programming any route in this case but we do have to publish response
+                         * for it because the route was already programmed by IntfOrch as part of interface configuration */
+                        publishRouteState(ctx, ReturnCode(SAI_STATUS_SUCCESS));
                         it = consumer.m_toSync.erase(it);
                     }
                     /* subnet route, vrf leaked route, etc */
@@ -2226,6 +2236,9 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
 
     notifyNextHopChangeObservers(vrf_id, ipPrefix, nextHops, true);
 
+    /* Publish and update APPL STATE DB route entry programming status */
+    publishRouteState(ctx, ReturnCode(SAI_STATUS_SUCCESS));
+
     /*
      * If the route uses a temporary synced NHG owned by NhgOrch, return false
      * in order to keep trying to update the route in case the NHG is updated,
@@ -2419,6 +2432,9 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
 
     SWSS_LOG_INFO("Remove route %s with next hop(s) %s",
             ipPrefix.to_string().c_str(), it_route->second.nhg_key.to_string().c_str());
+    
+    /* Publish removal status, removes route entry from APPL STATE DB */
+    publishRouteState(ctx, ReturnCode(SAI_STATUS_SUCCESS));
 
     if (ipPrefix.isDefaultRoute() && vrf_id == gVirtualRouterId)
     {
@@ -2573,4 +2589,23 @@ void RouteOrch::decNhgRefCount(const std::string &nhg_index)
     {
         gCbfNhgOrch->decNhgRefCount(nhg_index);
     }
+}
+
+void RouteOrch::publishRouteState(const RouteBulkContext& ctx, const ReturnCode& status)
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<FieldValueTuple> fvs;
+
+    /* If the operation type is "DEL" then ctx.protocol is empty and fvs is left empty.
+     * An empty fvs makes ResponsePublisher::publish() remove the state entry from APPL_STATE_DB
+     */
+    if (!ctx.protocol.empty())
+    {
+        fvs.emplace_back("protocol", ctx.protocol);
+    };
+
+    const bool replace = true;
+
+    m_publisher.publish(APP_ROUTE_TABLE_NAME, ctx.key, fvs, status, replace);
 }

--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -122,8 +122,11 @@ struct RouteBulkContext
     // using_temp_nhg will track if the NhgOrch's owned NHG is temporary or not
     bool                                using_temp_nhg;
 
-    RouteBulkContext()
-        : excp_intfs_flag(false), using_temp_nhg(false)
+    std::string                         key;       // Key in database table
+    std::string                         protocol;  // Protocol string
+
+    RouteBulkContext(const std::string& key)
+        : key(key), excp_intfs_flag(false), using_temp_nhg(false)
     {
     }
 
@@ -139,6 +142,8 @@ struct RouteBulkContext
         excp_intfs_flag = false;
         vrf_id = SAI_NULL_OBJECT_ID;
         using_temp_nhg = false;
+        key.clear();
+        protocol.clear();
     }
 };
 
@@ -269,6 +274,8 @@ private:
     const NhgBase &getNhg(const std::string& nhg_index);
     void incNhgRefCount(const std::string& nhg_index);
     void decNhgRefCount(const std::string& nhg_index);
+
+    void publishRouteState(const RouteBulkContext& ctx, const ReturnCode& status);
 };
 
 #endif /* SWSS_ROUTEORCH_H */

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -165,4 +165,4 @@ tests_intfmgrd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/cfgmgr -I$(top_srcdi
 tests_intfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_intfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_intfmgrd_INCLUDES)
 tests_intfmgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
-        -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread
+        -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main

--- a/tests/mock_tests/fake_response_publisher.cpp
+++ b/tests/mock_tests/fake_response_publisher.cpp
@@ -2,6 +2,11 @@
 #include <vector>
 
 #include "response_publisher.h"
+#include "mock_response_publisher.h"
+
+/* This mock plugs into this fake response publisher implementation
+ * when needed to test code that uses response publisher. */
+std::unique_ptr<MockResponsePublisher> gMockResponsePublisher;
 
 ResponsePublisher::ResponsePublisher() : m_db("APPL_STATE_DB", 0) {}
 
@@ -9,12 +14,24 @@ void ResponsePublisher::publish(
     const std::string& table, const std::string& key,
     const std::vector<swss::FieldValueTuple>& intent_attrs,
     const ReturnCode& status,
-    const std::vector<swss::FieldValueTuple>& state_attrs, bool replace) {}
+    const std::vector<swss::FieldValueTuple>& state_attrs, bool replace)
+{
+    if (gMockResponsePublisher)
+    {
+        gMockResponsePublisher->publish(table, key, intent_attrs, status, state_attrs, replace);
+    }
+}
 
 void ResponsePublisher::publish(
     const std::string& table, const std::string& key,
     const std::vector<swss::FieldValueTuple>& intent_attrs,
-    const ReturnCode& status, bool replace) {}
+    const ReturnCode& status, bool replace)
+{
+    if (gMockResponsePublisher)
+    {
+        gMockResponsePublisher->publish(table, key, intent_attrs, status, replace);
+    }
+}
 
 void ResponsePublisher::writeToDB(
     const std::string& table, const std::string& key,

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -7,10 +7,14 @@
 #include "ut_helper.h"
 #include "mock_orchagent_main.h"
 #include "mock_table.h"
+#include "mock_response_publisher.h"
 #include "bulker.h"
 
 extern string gMySwitchType;
 
+extern std::unique_ptr<MockResponsePublisher> gMockResponsePublisher;
+
+using ::testing::_;
 
 namespace routeorch_test
 {
@@ -282,6 +286,10 @@ namespace routeorch_test
                                          {"mac_addr", "00:00:00:00:00:00" }});
             intfTable.set("Ethernet0:10.0.0.1/24", { { "scope", "global" },
                                                      { "family", "IPv4" }});
+            intfTable.set("Ethernet4", { {"NULL", "NULL" },
+                                         {"mac_addr", "00:00:00:00:00:00" }});
+            intfTable.set("Ethernet4:11.0.0.1/32", { { "scope", "global" },
+                                                     { "family", "IPv4" }});
             gIntfsOrch->addExistingData(&intfTable);
             static_cast<Orch *>(gIntfsOrch)->doTask();
 
@@ -421,5 +429,53 @@ namespace routeorch_test
         ASSERT_EQ(current_remove_count, remove_route_count);
         ASSERT_EQ(current_set_count + 1, set_route_count);
         ASSERT_EQ(sai_fail_count, 0);
+    }
+
+    TEST_F(RouteOrchTest, RouteOrchTestSetDelResponse)
+    {
+        gMockResponsePublisher = std::make_unique<MockResponsePublisher>();
+
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        std::string key = "2.2.2.0/24";
+        std::vector<FieldValueTuple> fvs{{"ifname", "Ethernet0,Ethernet0"}, {"nexthop", "10.0.0.2,10.0.0.3"}, {"protocol", "bgp"}};
+        entries.push_back({key, "SET", fvs});
+
+        auto consumer = dynamic_cast<Consumer *>(gRouteOrch->getExecutor(APP_ROUTE_TABLE_NAME));
+        consumer->addToSync(entries);
+
+        EXPECT_CALL(*gMockResponsePublisher, publish(APP_ROUTE_TABLE_NAME, key, std::vector<FieldValueTuple>{{"protocol", "bgp"}}, ReturnCode(SAI_STATUS_SUCCESS), true)).Times(1);
+        static_cast<Orch *>(gRouteOrch)->doTask();
+
+        entries.clear();
+
+        // Route deletion
+
+        entries.clear();
+        entries.push_back({key, "DEL", {}});
+
+        consumer->addToSync(entries);
+
+        EXPECT_CALL(*gMockResponsePublisher, publish(APP_ROUTE_TABLE_NAME, key, std::vector<FieldValueTuple>{}, ReturnCode(SAI_STATUS_SUCCESS), true)).Times(1);
+        static_cast<Orch *>(gRouteOrch)->doTask();
+
+        gMockResponsePublisher.reset();
+    }
+
+    TEST_F(RouteOrchTest, RouteOrchSetFullMaskSubnetPrefix)
+    {
+        gMockResponsePublisher = std::make_unique<MockResponsePublisher>();
+
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        std::string key = "11.0.0.1/32";
+        std::vector<FieldValueTuple> fvs{{"ifname", "Ethernet4"}, {"nexthop", "0.0.0.0"}, {"protocol", "bgp"}};
+        entries.push_back({key, "SET", fvs});
+
+        auto consumer = dynamic_cast<Consumer *>(gRouteOrch->getExecutor(APP_ROUTE_TABLE_NAME));
+        consumer->addToSync(entries);
+
+        EXPECT_CALL(*gMockResponsePublisher, publish(APP_ROUTE_TABLE_NAME, key, std::vector<FieldValueTuple>{{"protocol", "bgp"}}, ReturnCode(SAI_STATUS_SUCCESS), true)).Times(1);
+        static_cast<Orch *>(gRouteOrch)->doTask();
+
+        gMockResponsePublisher.reset();
     }
 }


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

I added ROUTE_TABLE entry programming status recording to APPL_STATE_DB. I made a ResponsePublisher work in buffered mode to be more optimized for route bulk processing.

I always publish a route entry with return code SAI_STATUS_SUCCESS because orchagent immidiatelly exits on any error.

**Why I did it**

I did it to support route supression in BGP. Orchagent has to sends route programming feedback back to fpmsyncd which communicates with zebra.

**How I verified it**

I wrote UT, also on the switch, you can run:

```
admin@sonic:~$ redis-cli -n 14 keys '*ROUTE*'
```

**Details if related**
