### PR TITLE
[portsorch] don't set serdes attributes when there's no change

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3757,12 +3757,6 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         m_portList[p.m_alias] = p;
                         updatePortStatePoll(p, PORT_STATE_POLL_LT, pCfg.link_training.value);
 
-                        // Restore pre-emphasis when LT is transitioned from ON to OFF
-                        if (!p.m_link_training && serdes_attr.empty())
-                        {
-                            serdes_attr = p.m_preemphasis;
-                        }
-
                         SWSS_LOG_NOTICE(
                             "Set port %s link training to %s",
                             p.m_alias.c_str(), m_portHlpr.getLinkTrainingStr(pCfg).c_str()
@@ -4170,15 +4164,9 @@ void PortsOrch::doPortTask(Consumer &consumer)
                     }
                 }
 
-                if (!serdes_attr.empty())
+                if (!serdes_attrs.empty() && p.m_preemphasis != serdes_attr)
                 {
-                    if (p.m_link_training)
-                    {
-                        SWSS_LOG_NOTICE("Save port %s preemphasis for LT", p.m_alias.c_str());
-                        p.m_preemphasis = serdes_attr;
-                        m_portList[p.m_alias] = p;
-                    }
-                    else
+                    if (!p.m_link_training)
                     {
                         if (p.m_admin_state_up)
                         {

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -886,6 +886,35 @@ namespace portsorch_test
         ASSERT_EQ(_sai_set_admin_state_down_count, ++current_sai_api_call_count);
         ASSERT_EQ(_sai_set_admin_state_up_count, current_sai_api_call_count);
 
+        // Configure non-serdes attribute that does not trigger admin state change
+        std::deque<KeyOpFieldsValuesTuple> kfvMtu = {{
+            "Ethernet0",
+            SET_COMMAND, {
+                { "mtu", "1234" },
+            }
+        }};
+
+        // Refill consumer
+        consumer->addToSync(kfvMtu);
+
+        _hook_sai_port_api();
+        current_sai_api_call_count = _sai_set_admin_state_down_count;
+
+        // Apply configuration
+        static_cast<Orch*>(gPortsOrch)->doTask();
+
+        _unhook_sai_port_api();
+
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", p));
+        ASSERT_TRUE(p.m_admin_state_up);
+
+        // Verify mtu is set
+        ASSERT_EQ(p.m_mtu, 1234);
+
+        // Verify no admin-disable then admin-enable
+        ASSERT_EQ(_sai_set_admin_state_down_count, current_sai_api_call_count);
+        ASSERT_EQ(_sai_set_admin_state_up_count, current_sai_api_call_count);
+
         // Dump pending tasks
         std::vector<std::string> taskList;
         gPortsOrch->dumpPendingTasks(taskList);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Fixing an issue when setting some port attribute in APPL_DB triggers serdes parameters to be re-programmed with port toggling.

I removed the code that cached serdes attributes into ```m_preemphasis``` when LT is on, since serdes attributes are always in ```pCfg``` and setting them only when LT is off.

**Why I did it**

To fix an issue seen on warm-reboot. After orchagent reconciles, portmgrd sends another update to APPL_DB PORT_TABLE to sync. Usually all the parameters are expected to be the same. e.g. speed, mtu, serdes attributes etc. unless a configuration change occurs or cable is reconnected. Normally that shouldn't happen during warm-reboot, so portsorch has a logic behind every attributes that if the cached value of the attribute is the same as the new one from the update then no operation is performed. This is how speed set is protected during warm-reboot, so that no port flapping occurs.

However, serdes attributes didn't have such protection check and unconditionally re-set serdes attributes on any port attribute change, e.g.:

```
config interface mtu Ethernet136 9100
```

```
2024-01-18.09:02:30.712260|s|SAI_OBJECT_TYPE_PORT:oid:0x100000000001e|SAI_PORT_ATTR_ADMIN_STATE=false
2024-01-18.09:02:30.718675|n|port_host_tx_ready|[{"host_tx_ready_status":"SAI_PORT_HOST_TX_READY_STATUS_NOT_READY","port_id":"oid:0x100000000001e","switch_id":"oid:0x21000000000000"}]|
2024-01-18.09:02:30.718724|g|SAI_OBJECT_TYPE_PORT:oid:0x100000000001e|SAI_PORT_ATTR_PORT_SERDES_ID=oid:0x0
2024-01-18.09:02:30.719833|G|SAI_STATUS_SUCCESS|SAI_PORT_ATTR_PORT_SERDES_ID=oid:0x5700000000056c
2024-01-18.09:02:30.719908|r|SAI_OBJECT_TYPE_PORT_SERDES:oid:0x5700000000056c
2024-01-18.09:02:30.721476|c|SAI_OBJECT_TYPE_PORT_SERDES:oid:0x5700000000056d|SAI_PORT_SERDES_ATTR_PORT_ID=oid:0x100000000001e|SAI_PORT_SERDES_ATTR_IDRIVER=8:60,60,60,60,60,60,60,60|SAI_PORT_SERDES_ATTR_TX_FIR_PRE1=8:-2,-2,-2,-2,-2,-2,-2,-2|SAI_PORT_SERDES_ATTR_TX_FIR_PRE2=8:0,0,0,0,0,0,0,0|SAI_PORT_SERDES_ATTR_TX_FIR_MAIN=8:32,32,32,32,32,32,32,32|SAI_PORT_SERDES_ATTR_TX_FIR_POST1=8:6,6,6,6,6,6,6,6|SAI_PORT_SERDES_ATTR_TX_PAM4_RATIO=8:4,4,4,4,4,4,4,4|SAI_PORT_SERDES_ATTR_TX_OUT_COMMON_MODE=8:15,15,15,15,15,15,15,15|SAI_PORT_SERDES_ATTR_TX_PMOS_COMMON_MODE=8:105,105,105,105,105,105,105,105|SAI_PORT_SERDES_ATTR_TX_NMOS_COMMON_MODE=8:95,95,95,95,95,95,95,95|SAI_PORT_SERDES_ATTR_TX_PMOS_VLTG_REG=8:30,30,30,30,30,30,30,30|SAI_PORT_SERDES_ATTR_TX_NMOS_VLTG_REG=8:170,170,170,170,170,170,170,170
2024-01-18.09:02:30.724023|s|SAI_OBJECT_TYPE_PORT:oid:0x100000000001e|SAI_PORT_ATTR_ADMIN_STATE=true
2024-01-18.09:02:30.727609|S|SAI_OBJECT_TYPE_ROUTE_ENTRY||{"dest":"::/0","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000006"}|SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION=SAI_PACKET_ACTION_DROP||{"dest":"::/0","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000006"}|SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID=oid:0x0||{"dest":"0.0.0.0/0","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000006"}|SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION=SAI_PACKET_ACTION_DROP||{"dest":"0.0.0.0/0","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000006"}|SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID=oid:0x0
2024-01-18.09:02:30.731232|s|SAI_OBJECT_TYPE_PORT:oid:0x100000000001e|SAI_PORT_ATTR_MTU=9122
2024-01-18.09:02:30.732856|s|SAI_OBJECT_TYPE_PORT:oid:0x100000000001e|SAI_PORT_ATTR_ADMIN_STATE=false
2024-01-18.09:02:30.736624|g|SAI_OBJECT_TYPE_PORT:oid:0x100000000001e|SAI_PORT_ATTR_PORT_SERDES_ID=oid:0x0
2024-01-18.09:02:30.737289|G|SAI_STATUS_SUCCESS|SAI_PORT_ATTR_PORT_SERDES_ID=oid:0x5700000000056d
2024-01-18.09:02:30.737345|r|SAI_OBJECT_TYPE_PORT_SERDES:oid:0x5700000000056d
2024-01-18.09:02:30.738226|c|SAI_OBJECT_TYPE_PORT_SERDES:oid:0x5700000000056e|SAI_PORT_SERDES_ATTR_PORT_ID=oid:0x100000000001e|SAI_PORT_SERDES_ATTR_IDRIVER=8:60,60,60,60,60,60,60,60|SAI_PORT_SERDES_ATTR_TX_FIR_PRE1=8:-2,-2,-2,-2,-2,-2,-2,-2|SAI_PORT_SERDES_ATTR_TX_FIR_PRE2=8:0,0,0,0,0,0,0,0|SAI_PORT_SERDES_ATTR_TX_FIR_MAIN=8:32,32,32,32,32,32,32,32|SAI_PORT_SERDES_ATTR_TX_FIR_POST1=8:6,6,6,6,6,6,6,6|SAI_PORT_SERDES_ATTR_TX_PAM4_RATIO=8:4,4,4,4,4,4,4,4|SAI_PORT_SERDES_ATTR_TX_OUT_COMMON_MODE=8:15,15,15,15,15,15,15,15|SAI_PORT_SERDES_ATTR_TX_PMOS_COMMON_MODE=8:105,105,105,105,105,105,105,105|SAI_PORT_SERDES_ATTR_TX_NMOS_COMMON_MODE=8:95,95,95,95,95,95,95,95|SAI_PORT_SERDES_ATTR_TX_PMOS_VLTG_REG=8:30,30,30,30,30,30,30,30|SAI_PORT_SERDES_ATTR_TX_NMOS_VLTG_REG=8:170,170,170,170,170,170,170,170
2024-01-18.09:02:30.740160|s|SAI_OBJECT_TYPE_PORT:oid:0x100000000001e|SAI_PORT_ATTR_ADMIN_STATE=true
2024-01-18.09:02:30.805561|n|port_host_tx_ready|[{"host_tx_ready_status":"SAI_PORT_HOST_TX_READY_STATUS_READY","port_id":"oid:0x100000000001e","switch_id":"oid:0x21000000000000"}]|
```

**How I verified it**

By changing mtu of the interface I verified there was not port toggling and running warm-reboot test on T0 topology.

**Details if related**
