### PR TITLE
[portsorch] Handle TRANSCEIVER_INFO table on warm boot

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3391,6 +3391,7 @@ bool PortsOrch::bake()
     addExistingData(APP_LAG_MEMBER_TABLE_NAME);
     addExistingData(APP_VLAN_TABLE_NAME);
     addExistingData(APP_VLAN_MEMBER_TABLE_NAME);
+    addExistingData(STATE_TRANSCEIVER_INFO_TABLE_NAME);
 
     return true;
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Process TRANSCEIVER_INFO STATE_DB table on warm start to configure SAI_PORT_ATTR_HOST_TX_SIGNAL_ENABLE on warm boot.

**Why I did it**

Fix an issue that the port becomes operationally down after APPLY_VIEW.

**How I verified it**

Run warm-reboot.

**Details if related**
