### PR TITLE
[saispy] restore original API pointer

### DIFF
--- a/tests/mock_tests/saispy.h
+++ b/tests/mock_tests/saispy.h
@@ -33,12 +33,25 @@ struct SaiSpyFunctor
     using original_fn_ptr_t = R (**)(arglist...);
 
     original_fn_t original_fn;
+    original_fn_ptr_t original_fn_ptr;
     static std::function<R(arglist...)> fake;
 
     SaiSpyFunctor(original_fn_ptr_t fn_ptr) :
-        original_fn(*fn_ptr)
+        original_fn(*fn_ptr),
+        original_fn_ptr(fn_ptr)
     {
         *fn_ptr = spy;
+    }
+
+    SaiSpyFunctor(const SaiSpyFunctor&) = delete;
+    SaiSpyFunctor &operator=(const SaiSpyFunctor&) = delete;
+
+    SaiSpyFunctor(SaiSpyFunctor&&) noexcept = delete;
+    SaiSpyFunctor &operator=(SaiSpyFunctor&&) noexcept = delete;
+
+    ~SaiSpyFunctor()
+    {
+        *original_fn_ptr = original_fn;
     }
 
     void callFake(std::function<sai_status_t(arglist...)> fn)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Restore original SAI API pointer in SaiSpyFunctor.

**Why I did it**

In UT, whenever SaiSpy was used the the original SAI function was not restored.
This causes crashes when tests are ran after another tests set SaiSpy as no cleanup of global state occurs after each test.

That's why reordering some tests may fail.

With this PR, the test can mock SAI function with SaiSpy and once the SaiSpyFunctor goes out of scope, the original VS lib SAI function pointer is restored.

**How I verified it**

Added UT.

**Details if related**
