### PR TITLE
[FC] Set FC delay in command line parameters

### DIFF
--- a/orchagent/flexcounterorch.h
+++ b/orchagent/flexcounterorch.h
@@ -11,6 +11,18 @@ extern "C" {
 #include "sai.h"
 }
 
+// Delay in seconds before flex counter processing begins after orchagent startup.
+// 
+// This delay improves boot time by prioritizing data plane configuration over
+// counter initialization. Systems with many ports, priority groups (PGs), and
+// queues require significant time to generate counter maps, which is not
+// immediately necessary during boot.
+// Value of 0 will process flex counters immediately.
+// 
+// Configured via orchagent command line argument: -D <delay_sec>
+// 
+extern uint32_t gFlexCounterDelaySec;
+
 const std::string createAllAvailableBuffersStr = "create_all_available_buffers";
 
 class FlexCounterQueueStates
@@ -73,8 +85,7 @@ private:
     Table m_bufferQueueConfigTable;
     Table m_bufferPgConfigTable;
     Table m_deviceMetadataConfigTable;
-    std::unique_ptr<SelectableTimer> m_delayTimer;
-    std::unique_ptr<Executor> m_delayExecutor;
+    SelectableTimer* m_delayTimer;
     std::unordered_set<std::string> m_groupsWithBulkChunkSize;
 };
 

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -103,6 +103,7 @@ void usage()
     cout << "    -v vrf: VRF name (default empty)" << endl;
     cout << "    -I heart_beat_interval: Heart beat interval in millisecond (default 10)" << endl;
     cout << "    -R enable the ring thread feature" << endl;
+    cout << "    -D Delay in seconds before flex counter processing begins after orchagent startup (default 0)" << endl;
 }
 
 void sighup_handler(int signo)
@@ -369,7 +370,7 @@ int main(int argc, char **argv)
     int record_type = 3; // Only swss and sairedis recordings enabled by default.
     long heartBeatInterval = HEART_BEAT_INTERVAL_MSECS_DEFAULT;
 
-    while ((opt = getopt(argc, argv, "b:m:r:f:j:d:i:hsz:k:q:c:t:v:I:R")) != -1)
+    while ((opt = getopt(argc, argv, "b:m:r:f:j:d:i:hsz:k:q:c:t:v:I:R:D:")) != -1)
     {
         switch (opt)
         {
@@ -486,6 +487,16 @@ int main(int argc, char **argv)
             break;
         case 'R':
             gRingMode = true;
+            break;
+        case 'D':
+            try
+            {
+                gFlexCounterDelaySec = swss::to_uint<uint32_t>(optarg);
+            }
+            catch (const std::exception& error)
+            {
+                SWSS_LOG_ERROR("Invalid flex counter delay sec [%s]: %s", optarg, error.what());
+            }
             break;
         default: /* '?' */
             exit(EXIT_FAILURE);

--- a/tests/mock_tests/flexcounter_ut.cpp
+++ b/tests/mock_tests/flexcounter_ut.cpp
@@ -274,13 +274,7 @@ namespace flexcounter_test
         sai_switch_api = pold_sai_switch_api;
     }
 
-    enum class StartType
-    {
-        Cold,
-        Warm,
-    };
-
-    struct FlexCounterTest : public ::testing::TestWithParam<std::tuple<bool, bool, StartType>>
+    struct FlexCounterTest : public ::testing::TestWithParam<std::tuple<bool, bool, uint32_t>>
     {
         shared_ptr<swss::DBConnector> m_app_db;
         shared_ptr<swss::DBConnector> m_config_db;
@@ -290,7 +284,6 @@ namespace flexcounter_test
         shared_ptr<swss::DBConnector> m_asic_db;
         shared_ptr<swss::DBConnector> m_flex_counter_db;
         bool create_only_config_db_buffers;
-        StartType m_start_type;
 
         FlexCounterTest()
         {
@@ -317,7 +310,7 @@ namespace flexcounter_test
 
             gTraditionalFlexCounter = get<0>(GetParam());
             create_only_config_db_buffers = get<1>(GetParam());
-            m_start_type = get<2>(GetParam());
+            gFlexCounterDelaySec = get<2>(GetParam());
 
             if (gTraditionalFlexCounter)
             {
@@ -364,17 +357,7 @@ namespace flexcounter_test
                 CFG_FLEX_COUNTER_TABLE_NAME
             };
 
-            if (m_start_type == StartType::Warm)
-            {
-                WarmStart::getInstance().m_enabled = true;
-            }
-
             auto* flexCounterOrch = new FlexCounterOrch(m_config_db.get(), flex_counter_tables);
-
-            if (m_start_type == StartType::Warm)
-            {
-                WarmStart::getInstance().m_enabled = false;
-            }
 
             gDirectory.set(flexCounterOrch);
 
@@ -441,6 +424,9 @@ namespace flexcounter_test
             gDirectory.m_values.clear();
 
             _unhook_sai_switch_api();
+
+            // reset flex counter delay sec
+            gFlexCounterDelaySec = 0;
         }
 
         static void SetUpTestCase()
@@ -634,7 +620,7 @@ namespace flexcounter_test
         flexCounterOrch->addExistingData(&flexCounterCfg);
         static_cast<Orch *>(flexCounterOrch)->doTask();
 
-        if (m_start_type == StartType::Warm)
+        if (gFlexCounterDelaySec > 0)
         {
             // Expire timer
             flexCounterOrch->doTask(*flexCounterOrch->m_delayTimer);
@@ -993,14 +979,16 @@ namespace flexcounter_test
         FlexCounterTests,
         FlexCounterTest,
         ::testing::Values(
-            std::make_tuple(false, true, StartType::Cold),
-            std::make_tuple(false, false, StartType::Cold),
-            std::make_tuple(true, true, StartType::Cold),
-            std::make_tuple(true, false, StartType::Cold),
-            std::make_tuple(false, true, StartType::Warm),
-            std::make_tuple(false, false, StartType::Warm),
-            std::make_tuple(true, true, StartType::Warm),
-            std::make_tuple(true, false, StartType::Warm))
+            // traditional_flex_counter, create_only_config_db_buffers, flex_counter_delay_sec
+            std::make_tuple(false, true, 0),
+            std::make_tuple(false, false, 0),
+            std::make_tuple(true, true, 0),
+            std::make_tuple(true, false, 0),
+            std::make_tuple(false, true, 120),
+            std::make_tuple(false, false, 120),
+            std::make_tuple(true, true, 120),
+            std::make_tuple(true, false, 120)
+        )
     );
 
     using namespace mock_orch_test;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

I implemented a configurable delay mechanism for flex counter processing in the SONiC orchagent. The changes include:
- Flex counters can be delayed not just for warm or fast boot but for cold boot as well
- Added a new command line parameter -D to set the flex counter delay in seconds
- Replaced the hardcoded 60-second delay with a configurable global variable gFlexCounterDelaySec
- Modified the flex counter initialization logic to only create delay timers when the delay is greater than 0
- Updated unit tests to test both immediate processing (delay=0) and delayed processing (delay=120) scenarios

In previous implementation, the delay was applicable to warm and fast boot, but never done for cold boot. 
This PR addresses that to improve cold boot time as well.
I left 0 sec delay as a default mainly due to VS test suite expecting FC counters to be set immediately.

**Why I did it**

The flex counter delay feature improves system boot time by prioritizing data plane configuration over counter initialization. Systems with many ports, priority groups (PGs), and queues require significant time to generate counter maps, which is not immediately necessary during boot. 

**How I verified it**

- Updated unit tests to cover both immediate (delay=0) and delayed (delay=120 seconds) processing scenarios
- Ensured the command line parameter parsing works correctly with proper error handling for invalid values
- Verified that the delay timer is only created when delay > 0, maintaining backward compatibility
- Added logging to show the configured delay value for debugging purposes

**Details if related**

The feature is particularly beneficial for large-scale deployments where boot time optimization is critical for operational efficiency.
