### PR TITLE
[portsorch] Fixed port comparison logic executed every doTask for every port

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4290,7 +4290,8 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 return true;
             };
 
-            if (m_portList.find(key) == m_portList.end())
+            const bool portExists = m_portList.count(key) > 0;
+            if (!portExists)
             {
                 // Aggregate configuration while the port is not created.
                 auto &fvMap = m_portConfigMap[key];
@@ -4322,18 +4323,12 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 }
             }
 
-            // TODO:
-            // Fix the issue below
-            // After PortConfigDone, while waiting for "PortInitDone" and the first gBufferOrch->isPortReady(alias),
-            // the complete m_lanesAliasSpeedMap may be populated again, so initExistingPort() will be called more than once
-            // for the same port.
-
             /* Once all ports received, go through the each port and perform appropriate actions:
              * 1. Remove ports which don't exist anymore
              * 2. Create new ports
              * 3. Initialize all ports
              */
-            if (getPortConfigState() != PORT_CONFIG_MISSING)
+            if (getPortConfigState() == PORT_CONFIG_RECEIVED)
             {
                 std::vector<PortConfig> portsToAddList;
                 std::vector<sai_object_id_t> portsToRemoveList;
@@ -4394,8 +4389,25 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
                 setPortConfigState(PORT_CONFIG_DONE);
             }
+            else if (getPortConfigState() == PORT_CONFIG_DONE)
+            {
+                // Add and initialize the port
+                if (!portExists)
+                {
+                    std::vector<PortConfig> portsToAddList { pCfg };
+                    std::vector<Port> addedPorts;
 
-            if (getPortConfigState() != PORT_CONFIG_DONE)
+                    if (!addPortBulk(portsToAddList, addedPorts))
+                    {
+                        SWSS_LOG_ERROR("Failed to add port %s", pCfg.key.c_str());
+                        it++;
+                        continue;
+                    }
+
+                    initPortsBulk(addedPorts);
+                }
+            }
+            else
             {
                 // Not yet receive PortConfigDone. Save it for future retry
                 it++;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
- Removed TODO comment about N² loop issue that was causing initExistingPort() to be called multiple times
- Fixed state checking logic to use explicit PORT_CONFIG_RECEIVED instead of != PORT_CONFIG_MISSING
- Added proper handling for PORT_CONFIG_DONE state to prevent duplicate port initialization
- Added error handling for port addition failures in the new state handling block
**Why I did it**

initExistingPort is beeing called 17 965 328 times on a system with 514 ports during cold boot and shows up in profilers. This is because the port comparison logic is invoked every port update and loops for every port. For every port that hasn't changed its lanes initPort is called. This is an N^2 loop and causes inefficient PORT table handling in cold boot. Saved around ~6 sec in cold boot downtime test with this change.

Port comparison logic runs only once when PortConfigDone is received.

**How I verified it**
- Verified port initialization works correctly in both initial and runtime port split cases.
- Confirmed no duplicate port initialization occurs

**Details if related**
