### PR TITLE
[RouteOrch] fix performance regression in ResponsePublisher

### DIFF
--- a/orchagent/response_publisher.h
+++ b/orchagent/response_publisher.h
@@ -60,6 +60,11 @@ class ResponsePublisher : public ResponsePublisherInterface
      */
     void setBuffered(bool buffered);
 
+
+    // When true, write attributes directly to DB without merge logic.
+    // When false (default), check for existing keys and filter NULL-valued attributes.
+    bool m_directDbWrite = false;
+
   private:
     struct entry
     {

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -55,6 +55,7 @@ RouteOrch::RouteOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames,
     SWSS_LOG_ENTER();
 
     m_publisher.setBuffered(true);
+    m_publisher.m_directDbWrite = true;
 
     sai_attribute_t attr;
     attr.id = SAI_SWITCH_ATTR_NUMBER_OF_ECMP_GROUPS;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

- Fix performance regression caused by https://github.com/sonic-net/sonic-swss/pull/3066 : `setBuffered` wasn't using Redis pipeline correctly.
- Add a flag to directly write attributes passed by the caller of `publish` API avoiding Redis `HGET` which breaks Redis pipeline.

**Why I did it**

Fix performance degradation observed in BGP suppress test.

**How I verified it**

- t1-lag BGP route test. Starting BGP sessions `config bgp startup all` and profile.
- BGP suppress FIB sonic-mgmt test

Without this change:

<img width="2082" height="1444" alt="image" src="https://github.com/user-attachments/assets/0c93e293-f2f2-4be9-9f50-16aafb31cad8" />

With this change:

<img width="2082" height="1444" alt="image" src="https://github.com/user-attachments/assets/80eee2ad-fbfd-40ec-bdc2-ffb031e6be9c" />

**Details if related**
